### PR TITLE
Fix overflow issue in letterboxing kernel

### DIFF
--- a/c/tensorConvert.cu
+++ b/c/tensorConvert.cu
@@ -21,6 +21,7 @@
  */
  
 #include "tensorConvert.h"
+#include <math.h>
 
 
 #define MIN(a,b)  (a < b ? a : b)
@@ -306,8 +307,8 @@ cudaError_t cudaLetterboxNorm( void* input, imageFormat format, size_t inputWidt
 		return cudaErrorInvalidValue;
 	}
 
-	const int padWidth = (float(outputWidth) - (float(inputWidth) * ratio)) / 2.0f;
-	const int padHeight = (float(outputHeight) - (float(inputHeight) * ratio)) / 2.0f;
+	const int padWidth = roundf((float(outputWidth) - (float(inputWidth) * ratio)) / 2.0f);
+	const int padHeight = roundf((float(outputHeight) - (float(inputHeight) * ratio)) / 2.0f);
 
 	// launch kernel
 	const dim3 blockDim(8, 8);


### PR DESCRIPTION
When we are using 1640x1232 camera resolution, our height padding ends up rounding to 79 instead of 80. This results in an buffer overrun - illegal memory access in the CUDA kernel when accessing the input image.

The fix is to correctly round the paddings so we are staying in the bounds of the input image.

The memory error was not reported on previous JetPacks (<6.2) due to using a legacy CUDA version.