### PR TITLE
Remove duplicate utils submodule definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,5 +28,3 @@
 [submodule "ros"]
 	path = ros
 	url = https://github.com/dusty-nv/ros_deep_learning
-[submodule "./utils/"]
-	url = git@github.com:st6io/jetson-inference.git


### PR DESCRIPTION
Somehow we got two submodule definitions for `utils`. This prevents us from pulling the correct one from our fork.