### PR TITLE
Fix camera timeouts when time changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "utils"]
 	path = utils
 	url = https://github.com/st6io/jetson-utils
-	branch = nvargus-exposure-compensation
+	branch = main
 [submodule "tools/camera-capture"]
 	path = tools/camera-capture
 	url = https://github.com/dusty-nv/camera-capture


### PR DESCRIPTION
This change applies the fix (https://github.com/st6io/jetson-utils/commit/2577c4f1806f142f389842fec29697d3db1f7fb8) for using monotonic clock (instead of realtime one) in the Jetson Utils module. This issue surfaces as camera timeouts when the system clock is being changed (for example via NTP updates).

Additionally this change correctly updates the `utils` submodule and points it to the `main` remote that we are going to use for our changes.