### PR TITLE
Enable interclass clustering

### DIFF
--- a/c/detectNet.cpp
+++ b/c/detectNet.cpp
@@ -51,6 +51,7 @@
 #define CHECK_NULL_STR(x)	(x != NULL) ? x : "NULL"
 
 //#define DEBUG_CLUSTERING
+#define CLUSTER_INTERCLASS 
 
 #define MIN(a,b)  (a < b ? a : b)
 


### PR DESCRIPTION
This change enables interclass clustering for detections. This will merge detections if they overlap and pick the one with the highest confidence.